### PR TITLE
Stubbed out whereIn

### DIFF
--- a/app/lib/com.alcoapps.dbhelper.js
+++ b/app/lib/com.alcoapps.dbhelper.js
@@ -116,6 +116,18 @@ dbhelper.prototype.get = function (obj, callback) {
     if (obj.limit) {
         sql += ' LIMIT ' + obj.limit
     }
+	if(obj.whereIn) {
+		var value = "";
+	
+		if (obj.whereIn instanceof Array) {
+			if (obj.whereIn.length > 0) {
+				value = '(\'' + obj.whereIn.join('\', \'') + '\')';
+			}
+		}
+	
+		sql += ' in ' + value;
+	}
+    
     if (callback) {
         callback(this.getData(sql));
     } else {


### PR DESCRIPTION
This will let a user do something like this:

   var myTable = App.Database.get({
       fields  : "*",
       table   : "myTable",
    where   : "someColumn",
    whereIn : ["hasThisValue", "andThisValue", "andThisOneToo"]
   });

Perhaps an enhancement to this would be where the dev doesn't have to specify "where", OR let them specify the column for the IN separate from the where (which is useful too).  
